### PR TITLE
Fix Twilio gather recording handling

### DIFF
--- a/Backend/app/api/endpoints/calls.py
+++ b/Backend/app/api/endpoints/calls.py
@@ -786,20 +786,22 @@ async def respond_and_record(request: Request):
                     # Fall back to fetching from Twilio REST API if the gather webhook did not include recording data yet
                     print(f"[RESPOND-AND-RECORD] No recording URL in form data - fetching from Twilio API...")
                     try:
-                        import time
-                        time.sleep(1)  # Wait 1 second for Twilio to process the recording
+                        max_attempts = 5
+                        latest_recording = None
 
-                        # Fetch recordings for this call from Twilio
-                        from app.services.twilio_service import twilio_service as tw_service
-                        recordings = tw_service.client.recordings.list(call_sid=call_sid, limit=1)
-                        print(f"[RESPOND-AND-RECORD] recording url value  {call_sid}")
-                        print(f"[RESPOND-AND-RECORD] recording url value  {recordings}")
-                        if recordings:
-                            latest_recording = recordings[0]
-                            recording_sid = latest_recording.sid
-                            recording_url = f"https://api.twilio.com{latest_recording.uri.replace('.json', '')}"
+                        for attempt in range(1, max_attempts + 1):
+                            latest_recording = twilio_service.get_latest_recording_for_call(call_sid)
+                            if latest_recording:
+                                break
 
-                            print(f"[RESPOND-AND-RECORD] Found recording: {recording_sid}")
+                            print(
+                                f"[RESPOND-AND-RECORD] Attempt {attempt}/{max_attempts}: recording not available yet, waiting..."
+                            )
+                            await asyncio.sleep(1.5)
+
+                        if latest_recording:
+                            recording_sid, recording_url = latest_recording
+                            print(f"[RESPOND-AND-RECORD] Found recording via API: {recording_sid}")
                             print(f"[RESPOND-AND-RECORD] Recording URL: {recording_url}")
 
                             # Download and store in S3
@@ -811,9 +813,9 @@ async def respond_and_record(request: Request):
                                 user_interaction.recording_url = recording_url
                                 db.commit()
                             else:
-                                print(f"[RESPOND-AND-RECORD] ERROR: Failed to download recording")
+                                print(f"[RESPOND-AND-RECORD] ERROR: Failed to download recording from Twilio API")
                         else:
-                            print(f"[RESPOND-AND-RECORD] No recordings found for this call yet")
+                            print(f"[RESPOND-AND-RECORD] No recordings found for this call after polling Twilio")
                     except Exception as rec_error:
                         print(f"[RESPOND-AND-RECORD] EXCEPTION fetching recording: {rec_error}")
                         import traceback

--- a/Backend/app/api/endpoints/calls.py
+++ b/Backend/app/api/endpoints/calls.py
@@ -766,27 +766,9 @@ async def respond_and_record(request: Request):
                 db.refresh(user_interaction)
                 user_interaction_id = user_interaction.id
 
-                # Try to fetch the most recent recording from Twilio API
-                # Since Twilio doesn't include recording in this request, we need to fetch it
-                print(f"[RESPOND-AND-RECORD] No recording URL in form data - fetching from Twilio API...")
-                try:
-                    import time
-                    time.sleep(1)  # Wait 1 second for Twilio to process the recording
-
-                    # Fetch recordings for this call from Twilio
-                    from app.services.twilio_service import twilio_service as tw_service
-                    recordings = tw_service.client.recordings.list(call_sid=call_sid, limit=1)
-                    print(f"[RESPOND-AND-RECORD] recording url value  {call_sid}")
-                    print(f"[RESPOND-AND-RECORD] recording url value  {recordings}")
-                    if recordings:
-                        latest_recording = recordings[0]
-                        recording_sid = latest_recording.sid
-                        recording_url = f"https://api.twilio.com{latest_recording.uri.replace('.json', '')}"
-
-                        print(f"[RESPOND-AND-RECORD] Found recording: {recording_sid}")
-                        print(f"[RESPOND-AND-RECORD] Recording URL: {recording_url}")
-
-                        # Download and store in S3
+                if recording_url and recording_sid:
+                    print(f"[RESPOND-AND-RECORD] Found recording in webhook payload: {recording_sid}")
+                    try:
                         s3_audio_url = twilio_service.download_and_store_recording(recording_url, call_sid)
                         if s3_audio_url:
                             print(f"[RESPOND-AND-RECORD] SUCCESS: Stored recording in S3: {s3_audio_url}")
@@ -795,13 +777,47 @@ async def respond_and_record(request: Request):
                             user_interaction.recording_url = recording_url
                             db.commit()
                         else:
-                            print(f"[RESPOND-AND-RECORD] ERROR: Failed to download recording")
-                    else:
-                        print(f"[RESPOND-AND-RECORD] No recordings found for this call yet")
-                except Exception as rec_error:
-                    print(f"[RESPOND-AND-RECORD] EXCEPTION fetching recording: {rec_error}")
-                    import traceback
-                    traceback.print_exc()
+                            print(f"[RESPOND-AND-RECORD] ERROR: Failed to download recording from webhook URL")
+                    except Exception as rec_error:
+                        print(f"[RESPOND-AND-RECORD] EXCEPTION storing webhook recording: {rec_error}")
+                        import traceback
+                        traceback.print_exc()
+                else:
+                    # Fall back to fetching from Twilio REST API if the gather webhook did not include recording data yet
+                    print(f"[RESPOND-AND-RECORD] No recording URL in form data - fetching from Twilio API...")
+                    try:
+                        import time
+                        time.sleep(1)  # Wait 1 second for Twilio to process the recording
+
+                        # Fetch recordings for this call from Twilio
+                        from app.services.twilio_service import twilio_service as tw_service
+                        recordings = tw_service.client.recordings.list(call_sid=call_sid, limit=1)
+                        print(f"[RESPOND-AND-RECORD] recording url value  {call_sid}")
+                        print(f"[RESPOND-AND-RECORD] recording url value  {recordings}")
+                        if recordings:
+                            latest_recording = recordings[0]
+                            recording_sid = latest_recording.sid
+                            recording_url = f"https://api.twilio.com{latest_recording.uri.replace('.json', '')}"
+
+                            print(f"[RESPOND-AND-RECORD] Found recording: {recording_sid}")
+                            print(f"[RESPOND-AND-RECORD] Recording URL: {recording_url}")
+
+                            # Download and store in S3
+                            s3_audio_url = twilio_service.download_and_store_recording(recording_url, call_sid)
+                            if s3_audio_url:
+                                print(f"[RESPOND-AND-RECORD] SUCCESS: Stored recording in S3: {s3_audio_url}")
+                                user_interaction.s3_audio_url = s3_audio_url
+                                user_interaction.recording_sid = recording_sid
+                                user_interaction.recording_url = recording_url
+                                db.commit()
+                            else:
+                                print(f"[RESPOND-AND-RECORD] ERROR: Failed to download recording")
+                        else:
+                            print(f"[RESPOND-AND-RECORD] No recordings found for this call yet")
+                    except Exception as rec_error:
+                        print(f"[RESPOND-AND-RECORD] EXCEPTION fetching recording: {rec_error}")
+                        import traceback
+                        traceback.print_exc()
         except Exception as db_error:
             logger.error(f"[{call_sid}] Database error storing user speech: {db_error}")
             db.rollback()
@@ -900,7 +916,7 @@ async def respond_and_record(request: Request):
             action=conversation_webhook,
             method="POST",
             speech_model="phone_call",
-            recording_enabled=True,
+            record=True,
             recording_status_callback=recording_status_callback,
             recording_status_callback_method="POST"
         )

--- a/Backend/app/services/twilio_service.py
+++ b/Backend/app/services/twilio_service.py
@@ -1,7 +1,7 @@
 import os
 import logging
 import uuid
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Tuple
 from datetime import datetime
 import boto3  # Re-enabled
 from botocore.exceptions import ClientError  # Re-enabled
@@ -264,6 +264,43 @@ class TwilioService:
                 "success": False,
                 "error": str(e)
             }
+
+    def get_latest_recording_for_call(self, call_sid: str) -> Optional[Tuple[str, str]]:
+        """Return the most recent recording SID and media URL for a given call."""
+        if not call_sid:
+            logger.warning("get_latest_recording_for_call called without a call SID")
+            return None
+
+        if not self.client:
+            logger.warning("Twilio client not initialized - cannot fetch recordings")
+            return None
+
+        try:
+            recordings = self.client.calls(call_sid).recordings.list(limit=1)
+            if not recordings:
+                logger.debug(f"No recordings found yet for call {call_sid}")
+                return None
+
+            latest_recording = recordings[0]
+            recording_sid = latest_recording.sid
+            recording_url = latest_recording.media_url
+
+            if recording_url and not recording_url.endswith(".mp3"):
+                recording_url = f"{recording_url}.mp3"
+
+            logger.debug(
+                "Fetched recording for call %s - SID: %s, URL: %s",
+                call_sid,
+                recording_sid,
+                recording_url,
+            )
+            return recording_sid, recording_url
+        except TwilioException as exc:
+            logger.warning(f"Twilio error fetching recordings for {call_sid}: {exc}")
+            return None
+        except Exception as exc:
+            logger.error(f"Unexpected error fetching recordings for {call_sid}: {exc}")
+            return None
 
     def transcribe_audio_with_whisper(self, audio_url: str) -> Optional[str]:
         """Transcribe audio using OpenAI Whisper."""


### PR DESCRIPTION
## Summary
- enable Twilio to send recording metadata by setting the gather record attribute
- store recordings from the webhook payload when available and only fall back to the REST lookup when necessary

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efed081ba48326b0fd7a1575e3abd1